### PR TITLE
fixed forgotten UFunction declaration for bound onStart and onDestroy…

### DIFF
--- a/Plugins/MultiplayerSessionPlugin/Source/MultiplayerSessionPlugin/Public/Menu.h
+++ b/Plugins/MultiplayerSessionPlugin/Source/MultiplayerSessionPlugin/Public/Menu.h
@@ -28,7 +28,11 @@ protected:
 	void OnCreateSession(bool bWasSuccessful);
 	void OnFindSession(const TArray<FOnlineSessionSearchResult>& SearchResults, bool bWasSuccessful);
 	void OnJoinSession(EOnJoinSessionCompleteResult::Type Result);
+
+	UFUNCTION()
 	void OnStartSession(bool bWasSuccessful);
+
+	UFUNCTION()
 	void OnDestroySession(bool bWasSuccessful);
 	
 private: 


### PR DESCRIPTION
when hooking these up, the UFunction macro was left out for onStart and onDestroy, was causing a runtime crash.